### PR TITLE
refactor: modularize skill mapping logic and improve skill selection UX

### DIFF
--- a/client/src/app/(main)/profile/TechSkillsCard.tsx
+++ b/client/src/app/(main)/profile/TechSkillsCard.tsx
@@ -5,11 +5,27 @@ import { authFetch } from "@utils/authFetch";
 import { ShowcaseSectionSkill } from "components/Layouts/showcase-skill";
 
 type TechSkillsCardProps = {
-  techSkillMap: Map<string, [string, boolean]>;
+  skills: SkillsResponse;
+  userSkills: UserSkillsResponse;
   url: string;
 };
 
-const TechSkillsCard = ({ techSkillMap, url }: TechSkillsCardProps) => {
+type Skill = {
+  skillName: string;
+  skillId: string;
+};
+
+type SkillsResponse = {
+  technicalSkills: Skill[];
+  softSkills: Skill[];
+};
+
+type UserSkillsResponse = {
+  technicalSkills: Skill[];
+  softSkills: Skill[];
+};
+
+const TechSkillsCard = ({ skills, userSkills, url }: TechSkillsCardProps) => {
   const [selectedTechSkills, setSelectedTechSkills] = useState<string[]>([]);
   const [allTechSkills, setAllTechSkills] = useState<string[]>([]);
   const [searchTerm, setSearchTerm] = useState<string>("");
@@ -17,10 +33,30 @@ const TechSkillsCard = ({ techSkillMap, url }: TechSkillsCardProps) => {
   const [addSkills, setAddSkills] = useState<string[]>([]);
   const [deleteSkills, setDeleteSkills] = useState<string[]>([]);
   const [triggerSave, setTriggerSave] = useState<boolean>(false);
+  const [techSkillMap, setTechSkillMap] = useState<Map<
+    string,
+    [string, boolean]
+  > | null>(null);
+  const [isFocused, setIsFocused] = useState<boolean>(false);
 
   const MAX_SKILLS = 20;
 
   useEffect(() => {
+    const userTechSkillNames = new Set(
+      userSkills.technicalSkills.map((s) => s.skillName)
+    );
+    const techSkillMap = new Map<string, [string, boolean]>(
+      skills.technicalSkills.map((skill) => [
+        skill.skillName,
+        [skill.skillId, userTechSkillNames.has(skill.skillName)],
+      ])
+    );
+
+    setTechSkillMap(techSkillMap);
+  }, []);
+
+  useEffect(() => {
+    if (!techSkillMap) return;
     const selected: string[] = [];
     const all: string[] = [];
 
@@ -47,9 +83,6 @@ const TechSkillsCard = ({ techSkillMap, url }: TechSkillsCardProps) => {
         console.error("Failed to update skills:", error);
       }
 
-      console.log("Skills to add:", addSkills);
-      console.log("Skills to delete:", deleteSkills);
-
       setAddSkills([]);
       setDeleteSkills([]);
       setTriggerSave(false);
@@ -58,30 +91,22 @@ const TechSkillsCard = ({ techSkillMap, url }: TechSkillsCardProps) => {
     patchData();
   }, [triggerSave]);
 
-  useEffect(() => {
-    console.log(addSkills);
-  }, [addSkills]);
-
-  useEffect(() => {
-    console.log(deleteSkills);
-  }, [deleteSkills]);
-
   const filteredSkills = allTechSkills.filter(
     (skill) =>
-      skill.toLowerCase().includes(searchTerm.toLowerCase()) &&
-      !selectedTechSkills.includes(skill)
+      !selectedTechSkills.includes(skill) &&
+      skill.toLowerCase().includes(searchTerm.toLowerCase())
   );
 
   const addSkill = (skill: string) => {
     if (selectedTechSkills.length >= MAX_SKILLS) return;
     setSelectedTechSkills([...selectedTechSkills, skill]);
-    setAddSkills([...addSkills, techSkillMap.get(skill)![0]]);
+    setAddSkills([...addSkills, techSkillMap?.get(skill)![0]]);
     setSearchTerm("");
   };
 
   const removeSkill = (skill: string) => {
     setSelectedTechSkills(selectedTechSkills.filter((s) => s !== skill));
-    setDeleteSkills([...deleteSkills, techSkillMap.get(skill)![0]]);
+    setDeleteSkills([...deleteSkills, techSkillMap?.get(skill)![0]]);
   };
 
   return (
@@ -112,38 +137,42 @@ const TechSkillsCard = ({ techSkillMap, url }: TechSkillsCardProps) => {
       }
     >
       <div className="flex flex-col justify-between h-full">
-  
         {isEditing && (
           <div className="relative">
             <input
               type="text"
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
+              onFocus={() => setIsFocused(true)}
+              onBlur={() => setTimeout(() => setIsFocused(false), 100)}
               placeholder="Buscar habilidad"
               className="w-full rounded-lg border border-gray-3 bg-white dark:border-dark-3 dark:bg-dark-2 px-4 py-2 text-sm placeholder:text-gray-500 focus:outline-primary"
             />
-            {searchTerm && (
+            {isFocused && (
               <div className="absolute z-20 mt-1 max-h-40 w-full overflow-y-auto rounded-lg border dark:border-dark-3 dark:bg-dark-2 border-gray-3 bg-white text-sm shadow-lg">
-                {filteredSkills.slice(0, 10).map((skill) => (
-                  <div
-                    key={skill}
-                    className="cursor-pointer px-4 py-2 hover:bg-gray-2 dark:hover:bg-gray-7"
-                    onClick={() => addSkill(skill)}
-                  >
-                    {skill}
-                  </div>
-                ))}
+                {(searchTerm === "" ? allTechSkills : filteredSkills)
+                  .filter((skill) => !selectedTechSkills.includes(skill))
+                  .slice(0, 10)
+                  .map((skill) => (
+                    <div
+                      key={skill}
+                      className="cursor-pointer px-4 py-2 hover:bg-gray-2 dark:hover:bg-gray-7"
+                      onClick={() => addSkill(skill)}
+                    >
+                      {skill}
+                    </div>
+                  ))}
               </div>
             )}
           </div>
         )}
-  
+
         <div className="flex flex-col flex-grow">
-        <div
-  className={`flex flex-wrap items-start gap-2.5 overflow-y-auto pr-1 pt-1  ${
-    isEditing ? "h-[5rem]" : "h-[8rem]"
-  }`}
->
+          <div
+            className={`flex flex-wrap items-start gap-2.5 overflow-y-auto pr-1 pt-1  ${
+              isEditing ? "h-[5rem]" : "h-[8rem]"
+            }`}
+          >
             {selectedTechSkills.map((skill) => (
               <span
                 key={skill}
@@ -166,7 +195,6 @@ const TechSkillsCard = ({ techSkillMap, url }: TechSkillsCardProps) => {
       </div>
     </ShowcaseSectionSkill>
   );
-  
 };
 
 export default TechSkillsCard;

--- a/client/src/app/(main)/profile/page.tsx
+++ b/client/src/app/(main)/profile/page.tsx
@@ -44,10 +44,9 @@ const Page = () => {
   const router = useRouter();
   const [profile, setProfile] = useState<ProfileData | null>(null);
   const [loading, setLoading] = useState(true);
-  const [techSkillMap, setTechSkillMap] = useState<Map<
-    string,
-    [string, boolean]
-  > | null>(null);
+  const [skills, setSkills] = useState<SkillsResponse>(null);
+  const [userSkills, setUserSKills] = useState<UserSkillsResponse>(null);
+
   const [softSkillMap, setSoftSkillMap] = useState<Map<
     string,
     [string, boolean]
@@ -83,15 +82,8 @@ const Page = () => {
           position: userData.position || "Front-end Developer",
         });
 
-        const userTechSkillNames = new Set(
-          userSkills.technicalSkills.map((s) => s.skillName)
-        );
-        const techSkillMap = new Map<string, [string, boolean]>(
-          skills.technicalSkills.map((skill) => [
-            skill.skillName,
-            [skill.skillId, userTechSkillNames.has(skill.skillName)],
-          ])
-        );
+        setSkills(skills);
+        setUserSKills(userSkills);
 
         const userSoftSkillNames = new Set(
           userSkills.softSkills.map((s) => s.skillName)
@@ -103,7 +95,6 @@ const Page = () => {
           ])
         );
 
-        setTechSkillMap(techSkillMap);
         setSoftSkillMap(softSkillMap);
         setLoading(false);
       } catch (err) {
@@ -122,8 +113,8 @@ const Page = () => {
         <div className="grid gap-4 sm:grid-cols-2 sm:gap-6 2xl:gap-7.5">
           <PersonalInfoForm userData={profile} />
           <div className="max-h-auto flex flex-col gap-5">
-            <TechSkillsCard techSkillMap={techSkillMap} url={url} />
-            <SoftSkillsCard softSkillMap={softSkillMap} url={url} />
+            <TechSkillsCard skills={skills} userSkills={userSkills} url={url} />
+            <SoftSkillsCard skills={skills} userSkills={userSkills} url={url} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
- Moved creation of skill hash maps (Map<string, [id, isSelected]>) for technical and soft skills from `Page.tsx` into their respective components (`TechSkillsCard` and `SoftSkillsCard`) for better modularity and separation of concerns.
- Simplified component responsibility: each card now manages its own skill map and selection logic internally.
- Enhanced UX for skill selection inputs:
  - Skill list dropdown now shows all available skills on focus.
  - Filters skills dynamically as the user types.
  - Excludes already selected skills from suggestions.