### PR TITLE
fix(courses): replace find() with findOne() in getCourseInfo to fetch single course object

### DIFF
--- a/server/src/courses/courses.controller.ts
+++ b/server/src/courses/courses.controller.ts
@@ -46,7 +46,7 @@ export class CoursesController {
   @UseGuards(JwtGuard)
   async getCourseInfo(
     @Req() req: Request,
-    @Param('coueseId') courseId: string,
+    @Param('courseId') courseId: string,
   ): Promise<GetCourseInfoDto> {
     const employeeId = req.user['employeeId'];
     return this.employeeCourseService.getCourseInfo(employeeId, courseId);

--- a/server/src/courses/service/employeeCourses.service.ts
+++ b/server/src/courses/service/employeeCourses.service.ts
@@ -53,14 +53,15 @@ export class employeeCoursesService {
     courseId: string,
   ): Promise<GetCourseInfoDto> {
     try {
-      const course = await this.employeeCoursesRepository.find({
-        where: { employeeId: employeeId, courseId: courseId },
+      const employeeCoursesLink = await this.employeeCoursesRepository.findOne({
+        where: { employeeId, courseId },
         relations: ['employee', 'course'],
       });
-      const employeeCoursesLink = course[0];
+
       if (!employeeCoursesLink) {
         throw new InternalServerErrorException('Course not found');
       }
+
       const courseInfo: GetCourseInfoDto = {
         title: employeeCoursesLink.course.title,
         duration: employeeCoursesLink.course.duration,
@@ -70,6 +71,8 @@ export class employeeCoursesService {
         mandatory: employeeCoursesLink.course.mandatory,
         createdAt: employeeCoursesLink.course.createdAt,
       };
+
+      Logger.log(courseInfo);
 
       return courseInfo;
     } catch (error) {


### PR DESCRIPTION
- Ensures direct retrieval of the employee-course link without array indexing
- Prevents incorrect or ambiguous access to course data