### PR TITLE
feat(auth): add JWT-based client auth guard and role-aware navigation

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -15,6 +15,7 @@
         "flatpickr": "^4.6.13",
         "framer-motion": "^12.12.1",
         "jsvectormap": "^1.6.0",
+        "jwt-decode": "^4.0.0",
         "lucide-react": "^0.511.0",
         "next": "15.2.4",
         "next-auth": "^4.24.11",
@@ -4773,6 +4774,15 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,7 @@
     "flatpickr": "^4.6.13",
     "framer-motion": "^12.12.1",
     "jsvectormap": "^1.6.0",
+    "jwt-decode": "^4.0.0",
     "lucide-react": "^0.511.0",
     "next": "15.2.4",
     "next-auth": "^4.24.11",

--- a/client/src/app/(main)/ClientLayout.tsx
+++ b/client/src/app/(main)/ClientLayout.tsx
@@ -17,13 +17,30 @@ export default function ClientLayout({
 
   useEffect(() => {
     const token = localStorage.getItem("token");
+    const rol = localStorage.getItem("rol");
 
     if (!token && pathname !== "/login") {
       router.push("/login");
       setAuthorized(false);
-    } else {
-      setAuthorized(true);
+      return;
     }
+
+    if (
+      rol === "manager" &&
+      ["/Aplicacion", "/my-projects"].includes(pathname)
+    ) {
+      router.push("/dashboard");
+      setAuthorized(false);
+      return;
+    }
+
+    if (rol === "STAFF" && pathname === "/Project-Manager") {
+      router.push("/dashboard");
+      setAuthorized(false);
+      return;
+    }
+
+    setAuthorized(true);
   }, [pathname, router]);
 
   if (authorized === null) {

--- a/client/src/app/(main)/profile/page.tsx
+++ b/client/src/app/(main)/profile/page.tsx
@@ -95,9 +95,7 @@ const Page = () => {
     setProfile((prev) => ({ ...prev, ...newData }));
   };
 
-
   const handleApply = () => {
-    // enviar soliciutd al backlend
     alert("¡Solicitud enviada con éxito!");
   };
 
@@ -115,7 +113,7 @@ const Page = () => {
       )}
 
       <div
-        className={`mx-auto w-full max-w-[970px] transition-opacity duration-500 ${
+        className={`mx-auto w-full max-w-[970px] transition-opacity duration-300 ${
           fadeIn ? "opacity-100" : "opacity-0"
         }`}
       >

--- a/client/src/app/login/LoginClient.tsx
+++ b/client/src/app/login/LoginClient.tsx
@@ -1,5 +1,3 @@
-
-
 "use client";
 
 import React, { useEffect, useState } from "react";
@@ -10,6 +8,15 @@ import LoadingPage from "components/LoadingPage";
 import LoginError from "./LoginError";
 import Login from "./Login";
 import { authFetch } from "@utils/authFetch";
+import { jwtDecode } from "jwt-decode";
+
+interface JwtPayload {
+  employeeId: string;
+  password: string;
+  rol: string;
+  iat: number;
+  exp: number;
+}
 
 const LoginClient = () => {
   const [loading, setLoading] = useState(true);
@@ -44,6 +51,8 @@ const LoginClient = () => {
         } else {
           const { accessToken } = response;
           localStorage.setItem("token", accessToken);
+          const decoded: any = jwtDecode<JwtPayload>(accessToken);
+          localStorage.setItem("rol", decoded.rol);
           router.push("/dashboard");
         }
       } catch (err) {
@@ -58,7 +67,6 @@ const LoginClient = () => {
   return (
     <LoadingPage loading={loading}>
       <div className="relative h-screen w-full overflow-hidden px-4 flex items-center justify-center">
-
         {/* Background animation */}
         <motion.div
           className="absolute inset-0 z-0"
@@ -79,7 +87,6 @@ const LoginClient = () => {
 
         {/* Main Content */}
         <div className="w-full max-w-7xl h-full grid grid-cols-1 md:grid-cols-2 place-items-center relative z-10">
-          
           {/* Login Form Card */}
           <motion.div
             initial={{ x: -300, opacity: 0 }}
@@ -106,7 +113,9 @@ const LoginClient = () => {
               }}
               onMouseLeave={() => setTilt({ x: 0, y: 0 })}
             >
-              <h1 className="text-3xl font-light text-purple-600 mb-8 text-center">Path Explorer</h1>
+              <h1 className="text-3xl font-light text-purple-600 mb-8 text-center">
+                Path Explorer
+              </h1>
 
               <Login
                 email={email}
@@ -115,8 +124,6 @@ const LoginClient = () => {
                 setPassword={setPassword}
                 setTrigger={setTrigger}
               />
-
-              
             </motion.div>
           </motion.div>
 

--- a/client/src/components/Layouts/header/user-info/index.tsx
+++ b/client/src/components/Layouts/header/user-info/index.tsx
@@ -25,6 +25,7 @@ export function UserInfo({ name, email, img, level }: UserInfoProps) {
 
   const handleLogout = () => {
     localStorage.removeItem("token");
+    localStorage.removeItem("rol");
     console.log("Token removed from local storage");
     router.push("/login");
   };
@@ -65,14 +66,14 @@ export function UserInfo({ name, email, img, level }: UserInfoProps) {
         <h2 className="sr-only">User information</h2>
 
         <figure className="flex items-center gap-2.5 px-5 py-3.5">
-            <Image
-              src={img}
-              alt={`Avatar for ${name}`}
-              width={48}
-              height={48}
-              className="rounded-full object-cover w-16 h-16"
-              role="presentation"
-            />
+          <Image
+            src={img}
+            alt={`Avatar for ${name}`}
+            width={48}
+            height={48}
+            className="rounded-full object-cover w-16 h-16"
+            role="presentation"
+          />
 
           <figcaption className="space-y-2 text-base font-medium">
             <div className="mb-2 leading-none text-dark dark:text-white">

--- a/client/src/components/Layouts/sidebar/index.tsx
+++ b/client/src/components/Layouts/sidebar/index.tsx
@@ -12,6 +12,8 @@ import { useSidebarContext } from "./sidebar-context";
 export function Sidebar() {
   const pathname = usePathname();
   const { setIsOpen, isOpen, isMobile, toggleSidebar } = useSidebarContext();
+  const rol =
+    typeof window !== "undefined" ? localStorage.getItem("rol") : null;
 
   return (
     <>
@@ -57,39 +59,55 @@ export function Sidebar() {
 
           {/* Navigation */}
           <div className="custom-scrollbar mt-6 flex-1 overflow-y-auto pr-3 min-[850px]:mt-10">
-            {NAV_DATA.map((section) => (
-              <div key={section.label} className="mb-6">
-                <h2 className="mb-5 text-sm font-medium text-dark-4 dark:text-dark-6">
-                  {section.label}
-                </h2>
+            {NAV_DATA.map((section) => {
+              const filteredItems = section.items.filter((item) => {
+                if (rol === "STAFF" && item.title === "Project Manager")
+                  return false;
+                if (
+                  rol === "manager" &&
+                  ["Aplicación a Proyectos", "Mis Proyectos"].includes(
+                    item.title
+                  )
+                )
+                  return false;
+                return true;
+              });
 
-                <nav role="navigation" aria-label={section.label}>
-                  <ul className="space-y-2">
-                    {section.items.map((item) => {
-                      const href =
-                        item.url ||
-                        "/" + item.title.toLowerCase().split(" ").join("-");
-                      return (
-                        <li key={item.title}>
-                          <MenuItem
-                            className="flex items-center gap-3 py-3"
-                            as="link"
-                            href={href}
-                            isActive={pathname === href}
-                          >
-                            <item.icon
-                              className="size-6 shrink-0"
-                              aria-hidden="true"
-                            />
-                            <span>{item.title}</span>
-                          </MenuItem>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                </nav>
-              </div>
-            ))}
+              if (filteredItems.length === 0) return null;
+
+              return (
+                <div key={section.label} className="mb-6">
+                  <h2 className="mb-5 text-sm font-medium text-dark-4 dark:text-dark-6">
+                    {section.label}
+                  </h2>
+                  <nav role="navigation" aria-label={section.label}>
+                    <ul className="space-y-2">
+                      {filteredItems.map((item) => {
+                        const href =
+                          item.url ||
+                          "/" + item.title.toLowerCase().split(" ").join("-");
+                        return (
+                          <li key={item.title}>
+                            <MenuItem
+                              className="flex items-center gap-3 py-3"
+                              as="link"
+                              href={href}
+                              isActive={pathname === href}
+                            >
+                              <item.icon
+                                className="size-6 shrink-0"
+                                aria-hidden="true"
+                              />
+                              <span>{item.title}</span>
+                            </MenuItem>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </nav>
+                </div>
+              );
+            })}
           </div>
         </div>
       </aside>

--- a/client/src/utils/authFetch.ts
+++ b/client/src/utils/authFetch.ts
@@ -31,6 +31,7 @@ export const authFetch = async <T = any>(
   } catch (err) {
     console.error("Fetch error:", err);
     localStorage.removeItem("token");
+    localStorage.removeItem("rol");
     return false;
   }
 };


### PR DESCRIPTION
- Integrated `jwt-decode` library to extract user role and ID from the access token
- On login, decoded the JWT to store the user's role (`rol`) in localStorage
- Enhanced `ClientLayout` to act as a client-side middleware for route protection:
  - Checks presence of token and role on every pathname change
  - Redirects unauthorized users to `/login`
  - Blocks access to certain routes based on role (e.g., 'manager' and 'STAFF' restrictions)
- Updated Sidebar navigation to dynamically hide menu items depending on the user role
- Improved `authFetch` to handle expired or invalid tokens:
  - Automatically removes token and role from localStorage
  - Prevents further requests when session is invalid
- Added logout functionality that clears token and role and navigates back to login